### PR TITLE
Alteração placeholder default de ComposedLabel

### DIFF
--- a/src/components/elements/label/ComposedLabel.tsx
+++ b/src/components/elements/label/ComposedLabel.tsx
@@ -18,7 +18,7 @@ export class ComposedLabel extends React.Component<ComposedLabelProps, any> {
 
     static defaultProps: ComposedLabelProps = {
         title: '',
-        placeholder: 'Não informada'
+        placeholder: 'Não informado'
     }
 
     render() {


### PR DESCRIPTION
"Não informado" cobre mais valores do que "Não informada"