### PR TITLE
add configure git step in publish-site action

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -25,5 +25,10 @@ jobs:
       - name: Build site
         run: yarn site:build
 
+      - name: Configure git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
       - name: Deploy site
         run: yarn site:deploy


### PR DESCRIPTION
fix problem with action https://github.com/laboratoriobridge/bold/actions/runs/3914729273/jobs/6692118038

highly inspired by https://github.com/actions/checkout#push-a-commit-using-the-built-in-token