### PR TITLE
[ Paginator ] Allow customization of underlying input maxLength prop

### DIFF
--- a/src/components/Paginator/Paginator.tsx
+++ b/src/components/Paginator/Paginator.tsx
@@ -22,10 +22,15 @@ export interface PaginatorProps {
    * Called when the current page is changed.
    */
   onChange?(page: number): void
+
+  /**
+   * Customize the maxLength prop of the paginator input.
+   */
+  maxLength?: number
 }
 
 export function Paginator(props: PaginatorProps) {
-  const { page, total, onChange } = props
+  const { page, total, onChange, maxLength } = props
   const locale = useLocale()
 
   const [inputValue, setInputValue] = useState<string>(`${page + 1}`)
@@ -86,7 +91,7 @@ export function Paginator(props: PaginatorProps) {
         onBlur={handleInputBlur}
         onKeyDown={handleInputKeyPress}
         clearable={false}
-        maxLength={4}
+        maxLength={maxLength ?? 4}
         title={locale.paginator.currentPage}
       />
 


### PR DESCRIPTION
Hey guys, how's it going

So, I faced this issue when building some really big tables in which I had more than 9999 pages. Right now, the underlying input length is limited (hardcoded) by 4:
[Paginator.tsx:89](https://github.com/laboratoriobridge/bold/blob/3e7d763ba3394c61105bd1efe739a98d9521381e/src/components/Paginator/Paginator.tsx#L89)

I just added a new prop to the Paginator, called `maxLength`, that can be used to customize the input
Thanks!