### PR TITLE
Fix outlier tooltip on charts

### DIFF
--- a/src/components/Chart/LineDot.tsx
+++ b/src/components/Chart/LineDot.tsx
@@ -21,12 +21,13 @@ export interface LineDotProps<XDomain> {
 export function LineDot<XDomain>(props: LineDotProps<XDomain>) {
   const { cx, cy, showTooltip, stroke, payload, value, xDomain, dataKey: seriesName, dotShape, tooltipRenderer } = props
   const { classes } = useStyles(createStyles)
+  const labelValue = payload.outlierspv?.value ?? (Array.isArray(value) ? value[value.length - 1] : value)
   return (
     <ChartTooltip
       showTooltip={showTooltip}
       seriesName={seriesName}
       label={payload.x}
-      value={Array.isArray(value) ? value[value.length - 1] : value}
+      value={labelValue}
       labelDomain={xDomain}
       renderer={tooltipRenderer}
     >


### PR DESCRIPTION
closes #905 

Tooltip was showing incorrect value when the dot on the chart was an outlier.